### PR TITLE
Expose and save Relay metrics

### DIFF
--- a/report.go
+++ b/report.go
@@ -84,7 +84,8 @@ type SummaryFileData struct {
 
 type TestResult struct {
 	*vegeta.Metrics
-	Stats map[string]Stats `json:"container_stats"`
+	Stats        map[string]Stats       `json:"container_stats"`
+	RelayMetrics map[string]interface{} `json:"relay_metrics,omitempty"`
 }
 
 type Stats struct {

--- a/template/docker-compose.yml.tmpl
+++ b/template/docker-compose.yml.tmpl
@@ -17,6 +17,7 @@ services:
     environment:
       RESULT_PATH: "/result/{{ .ResultPath }}"
       TARGET_CONTAINER_NAME: "{{ .App.ContainerName }}-{{ .RunName }}-{{ .ID }}"
+      HAS_RELAY: "{{ .NeedsRelay }}"
     depends_on:
     - "app"
   tfb-database:


### PR DESCRIPTION
This is a sanity check.

For instrumented apps, the number of Sentry (transaction) events sent to Relay should be equal to number of load generator requests, give or take lost requests (e.g. dropped in transport or not yet flushed).

A simple sanity check is to ensure that the number of incoming requests in Relay is greater than zero.

We output the total request count and a dump of the first request as part of the benchmark results. The first request serves both as an extra sanity check and as a potential way to automatically extract SDK information (we plan to include the SDK info in the final report in the future).

## Pending decision
- Should we actually fail the run if `relay_metrics.request <= 0`?
- Should we actually try to compare to the specific number of load generator requests made?

## Related
- #5, as this data might be included in the summary report in some form.