### PR TITLE
Add subcommand to generate HTML report on demand

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,22 +5,39 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
 var usage = `
-Usage:	%[1]s PLATFORM [PLATFORM ...]
+Usage:	%[1]s [run] PLATFORM [PLATFORM ...]
+
+Benchmark one or more platforms.
 
 Examples:
 %[1]s platform/python/django
-%[1]s platform/javascript/express
+%[1]s run platform/javascript/express
+
+Usage:	%[1]s report RESULT [RESULT ...]
+
+Print an HTML report summarizing the results of one or more benchmark runs.
+Reports are automatically created after a successful benchmark run.
+This subcommand allows re-generating a report from benchmark result data on demand.
+
+Examples:
+%[1]s result/python/django/20210818-082527-tbnfsga
+%[1]s result/python/django/20210818-*
 `
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(usage), filepath.Base(os.Args[0]))
+	fmt.Fprintln(os.Stderr)
+}
 
 func main() {
 	flag.Parse()
 	if len(flag.Args()) < 1 {
-		fmt.Fprintf(os.Stderr, strings.TrimSpace(usage), os.Args[0])
-		fmt.Fprintln(os.Stderr)
+		printUsage()
 		os.Exit(2)
 	}
 	defer func() {
@@ -28,7 +45,24 @@ func main() {
 			log.Fatal(err)
 		}
 	}()
-	for _, platform := range flag.Args() {
-		Benchmark(BenchmarkConfigFromPlatform(platform))
+	switch args := flag.Args(); args[0] {
+	case "report":
+		args = args[1:]
+		if len(args) == 0 {
+			printUsage()
+			os.Exit(2)
+		}
+		Report(args)
+	case "run":
+		args = args[1:]
+		fallthrough
+	default:
+		if len(args) == 0 {
+			printUsage()
+			os.Exit(2)
+		}
+		for _, platform := range args {
+			Benchmark(BenchmarkConfigFromPlatform(platform))
+		}
 	}
 }

--- a/report.go
+++ b/report.go
@@ -15,6 +15,22 @@ import (
 
 var summaryTemplate = template.Must(template.ParseFiles(filepath.Join("template", "summary.html.tmpl")))
 
+func Report(s []string) {
+	if len(s) != 1 {
+		panic("Reporting on multiple results is not supported yet")
+	}
+	report([]*RunResult{
+		{
+			Name: "baseline",
+			Path: filepath.Join(s[0], "baseline"),
+		},
+		{
+			Name: "instrumented",
+			Path: filepath.Join(s[0], "instrumented"),
+		},
+	})
+}
+
 func report(results []*RunResult) {
 	summaryFile := SummaryFile{
 		Data: make([]SummaryFileData, 2),


### PR DESCRIPTION
This is mostly useful while making improvements to the report, such that we can iterate on the output report without re-running slow benchmarks all the time.

Related to #5.