### PR TITLE
feat(compare): Compare run results using benchstat

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/perf/benchstat"
 )
+
+const BenchstatPrefix = "Benchmark"
 
 // Compare compares runs from the same platform
 func Compare(s []string) {
-
+	builders := make(map[string]*strings.Builder)
 	for _, path := range s {
 		info, err := os.Stat(path)
 		if err != nil {
@@ -27,8 +35,67 @@ func Compare(s []string) {
 		for _, f := range files {
 			if f.IsDir() {
 				name := f.Name()
-				fmt.Println(name)
+				p := filepath.Join(path, name)
+				if b, ok := builders[name]; ok {
+					addResult(b, p)
+				} else {
+					var sb strings.Builder
+					builders[name] = &sb
+					addResult(&sb, p)
+				}
 			}
 		}
 	}
+
+	c := &benchstat.Collection{
+		Alpha:      0.05,
+		AddGeoMean: false,
+		DeltaTest:  benchstat.UTest,
+	}
+
+	for key, b := range builders {
+		if err := c.AddFile(key, strings.NewReader(b.String())); err != nil {
+			panic(err)
+		}
+	}
+
+	tables := c.Tables()
+	var buf bytes.Buffer
+	benchstat.FormatText(&buf, tables)
+	os.Stdout.Write(buf.Bytes())
+}
+
+func addResult(b *strings.Builder, folderPath string) {
+	tr := readTestResult(filepath.Join(folderPath, "result.json"))
+
+	// Latencies
+	const LatenciesPrefix = BenchstatPrefix + "Latencies"
+	writeStat(b, LatenciesPrefix, "Total", "1", tr.Latencies.Total.Milliseconds())
+	writeStat(b, LatenciesPrefix, "Mean", "1", tr.Latencies.Mean.Milliseconds())
+	writeStat(b, LatenciesPrefix, "50th", "1", tr.Latencies.P50.Milliseconds())
+	writeStat(b, LatenciesPrefix, "90th", "1", tr.Latencies.P90.Milliseconds())
+	writeStat(b, LatenciesPrefix, "95th", "1", tr.Latencies.P95.Milliseconds())
+	writeStat(b, LatenciesPrefix, "95th", "1", tr.Latencies.P95.Milliseconds())
+	writeStat(b, LatenciesPrefix, "99th", "1", tr.Latencies.P99.Milliseconds())
+	writeStat(b, LatenciesPrefix, "Max", "1", tr.Latencies.Max.Milliseconds())
+	writeStat(b, LatenciesPrefix, "Min", "1", tr.Latencies.Min.Milliseconds())
+
+	// Other Metrics
+	writeStat(b, BenchstatPrefix, "Duration", "1", tr.Duration.Milliseconds())
+	writeStat(b, BenchstatPrefix, "Wait", "1", tr.Wait.Milliseconds())
+	writeStat(b, BenchstatPrefix, "Requests", "1", int64(tr.Requests))
+	writeStat(b, BenchstatPrefix, "Rate", "1", int64(tr.Rate))
+	writeStat(b, BenchstatPrefix, "Throughput", "1", int64(tr.Throughput))
+}
+
+func writeStat(b *strings.Builder, prefix, suffix, iterations string, value int64) {
+	b.WriteString(prefix)
+	b.WriteString(suffix)
+	b.WriteRune(' ')
+	b.WriteString(iterations)
+	b.WriteRune(' ')
+	b.WriteString(strconv.FormatInt(value, 10))
+	b.WriteRune(' ')
+	b.WriteString("ms")
+	b.WriteRune('\n')
 }

--- a/compare.go
+++ b/compare.go
@@ -47,11 +47,7 @@ func Compare(s []string) {
 		}
 	}
 
-	c := &benchstat.Collection{
-		Alpha:      0.05,
-		AddGeoMean: false,
-		DeltaTest:  benchstat.UTest,
-	}
+	c := &benchstat.Collection{}
 
 	for key, b := range builders {
 		if err := c.AddFile(key, strings.NewReader(b.String())); err != nil {

--- a/compare.go
+++ b/compare.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// Compare compares runs from the same platform
+func Compare(s []string) {
+
+	for _, path := range s {
+		info, err := os.Stat(path)
+		if err != nil {
+			panic(err)
+		}
+
+		if !info.Mode().IsDir() {
+			panic(fmt.Errorf("[compare] %s is not a valid path", path))
+		}
+
+		files, err := ioutil.ReadDir(path)
+		if err != nil {
+			panic(err)
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				name := f.Name()
+				fmt.Println(name)
+			}
+		}
+	}
+}

--- a/compare.go
+++ b/compare.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,6 +16,10 @@ const BenchstatPrefix = "Benchmark"
 
 // Compare compares runs from the same platform
 func Compare(s []string) {
+	if len(s) < 2 {
+		log.Fatalf("compare requires more than one result")
+	}
+
 	builders := make(map[string]*strings.Builder)
 	for _, path := range s {
 		info, err := os.Stat(path)
@@ -24,7 +28,7 @@ func Compare(s []string) {
 		}
 
 		if !info.Mode().IsDir() {
-			panic(fmt.Errorf("[compare] %s is not a valid path", path))
+			continue
 		}
 
 		files, err := ioutil.ReadDir(path)

--- a/compare_test.go
+++ b/compare_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteStat(t *testing.T) {
+	var b strings.Builder
+
+	writeStat(&b, BenchstatPrefix, "Latencies", "1", time.Duration(11703760800).Milliseconds())
+
+	got := b.String()
+	want := "BenchmarkLatencies 1 11703 ms\n"
+
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/getsentry/sentry-sdk-benchmark
 
 go 1.17
 
-require github.com/tsenart/vegeta/v12 v12.8.4
+require (
+	github.com/tsenart/vegeta/v12 v12.8.4
+	golang.org/x/perf v0.0.0-20210220033136-40a54f11e909
+)
 
 require (
 	github.com/google/go-cmp v0.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+cloud.google.com/go v0.0.0-20170206221025-ce650573d812/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190129172621-c8b1d7a94ddf/go.mod h1:aJ4qN3TfrelA6NZ6AXsXRfmEVaYin3EDbSPJrKS8OXo=
+github.com/aclements/go-gg v0.0.0-20170118225347-6dbb4e4fefb0/go.mod h1:55qNq4vcpkIuHowELi5C8e+1yUHtoLoOUR9QU5j7Tes=
+github.com/aclements/go-moremath v0.0.0-20161014184102-0ff62e0875ff/go.mod h1:idZL3yvz4kzx1dsBOAC+oYv6L92P1oFEhUXUB1A/lwQ=
 github.com/alecthomas/jsonschema v0.0.0-20180308105923-f2c93856175a/go.mod h1:qpebaTNSsyUn5rPSJMsfqEtDw71TTggXM6stUDI16HA=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
@@ -8,6 +12,8 @@ github.com/dgryski/go-gk v0.0.0-20140819190930-201884a44051 h1:ByJUvQYyTtNNCVfYN
 github.com/dgryski/go-gk v0.0.0-20140819190930-201884a44051/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=
 github.com/dgryski/go-lttb v0.0.0-20180810165845-318fcdf10a77/go.mod h1:Va5MyIzkU0rAM92tn3hb3Anb7oz7KcnixF49+2wOMe4=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac/go.mod h1:P32wAyui1PQ58Oce/KYkOqQv8cVw1zAapXOl+dRFGbc=
 github.com/gonum/diff v0.0.0-20181124234638-500114f11e71/go.mod h1:22dM4PLscQl+Nzf64qNBurVJvfyvZELT0iRW2l/NN70=
 github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82/go.mod h1:PxC8OnwL11+aosOB5+iEPoV3picfs8tUpkVd0pDo+Kg=
@@ -20,6 +26,7 @@ github.com/gonum/stat v0.0.0-20181125101827-41a0da705a5b/go.mod h1:Z4GIJBJO3Wa4g
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/googleapis/gax-go v0.0.0-20161107002406-da06d194a00e/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/influxdata/tdigest v0.0.0-20180711151920-a7d76c6f093a/go.mod h1:9GkyshztGufsdPQWjH+ifgnIr3xNUL5syI70g2dzU1o=
 github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/ZzIY=
 github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
@@ -28,6 +35,7 @@ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFF
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/miekg/dns v1.1.17/go.mod h1:WgzbA6oji13JREwiNsRDNfl7jYdPnmz+VEuLrA+/48M=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 h1:7z3LSn867ex6VSaahyKadf4WtSsJIgne6A1WLOAGM8A=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
@@ -46,11 +54,17 @@ golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+o
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/oauth2 v0.0.0-20170207211851-4464e7848382/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/perf v0.0.0-20210220033136-40a54f11e909 h1:rWw0Gj4DMl/2otJ8CnfTcwOWkpROAc6qhXXoMrYOCgo=
+golang.org/x/perf v0.0.0-20210220033136-40a54f11e909/go.mod h1:KRSrLY7jerMEa0Ih7gBheQ3FYDiSx6liMnniX1o3j2g=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -75,5 +89,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca h1:PupagGYwj8+I4ubCxcmcBRk3VlUWtTg5huQpZR9flmE=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
+google.golang.org/api v0.0.0-20170206182103-3d017632ea10/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/grpc v0.0.0-20170208002647-2a6bf6142e96/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ Usage:	%[1]s compare RESULT [RESULT ...]
 Compares various runs using benchstat.
 
 Examples:
-%[1]s compare result/python/django/20210818-082527-tbnfsga
+%[1]s compare result/python/django/20210818-082527-tbnfsga result/platform/python/django/20210909-150838-bcvjada
 %[1]s compare result/python/django/20210818-*
 `
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,14 @@ This subcommand allows re-generating a report from benchmark result data on dema
 Examples:
 %[1]s report result/python/django/20210818-082527-tbnfsga
 %[1]s report result/python/django/20210818-*
+
+Usage:	%[1]s compare RESULT [RESULT ...]
+
+Compares various runs using benchstat.
+
+Examples:
+%[1]s compare result/python/django/20210818-082527-tbnfsga
+%[1]s compare result/python/django/20210818-*
 `
 
 func printUsage() {
@@ -76,6 +84,9 @@ func main() {
 			openBrowser = false
 		}
 		Report(args)
+	case "compare":
+		args = args[1:]
+		Compare(args)
 	case "run":
 		args = args[1:]
 		fallthrough


### PR DESCRIPTION
Compares runs by reading `result.json` from each result path, and then aggregating the numerical values with benchstat.

Open questions will be added as PR review comments.

Not sure why it's still `old` and `new`, I pass in the `instrumented` and `baseline` as the name.

```
name            old ms      new ms       delta
LatenciesTotal  9.70k ± 9%  11.39k ± 3%  +17.50%  (p=0.029 n=4+4)
LatenciesMean    31.8 ± 9%    37.5 ± 4%  +18.11%  (p=0.029 n=4+4)
Latencies50th    31.5 ± 8%    37.0 ± 3%  +17.46%  (p=0.029 n=4+4)
Latencies90th    40.8 ± 9%    46.8 ± 5%  +14.72%  (p=0.029 n=4+4)
Latencies95th    43.2 ± 8%    49.5 ± 3%  +14.45%  (p=0.000 n=8+8)
Latencies99th    51.8 ±24%    59.8 ±17%     ~     (p=0.200 n=4+4)
LatenciesMax     68.2 ±33%    70.8 ±10%     ~     (p=0.657 n=4+4)
LatenciesMin     14.5 ±17%    20.0 ±20%     ~     (p=0.057 n=4+4)
Duration        29.9k ± 0%   29.9k ± 0%     ~     (p=0.400 n=4+4)
Wait             24.8 ±41%    34.2 ±18%     ~     (p=0.086 n=4+4)
Requests          300 ± 0%     300 ± 0%     ~     (all equal)
Rate             10.0 ± 0%    10.0 ± 0%     ~     (all equal)
Throughput       10.0 ± 0%    10.0 ± 0%     ~     (all equal)
```