### PR TITLE
report: RelayMetrics typed and per test run

### DIFF
--- a/report_test.go
+++ b/report_test.go
@@ -32,28 +32,18 @@ func Test_formatSDKName(t *testing.T) {
 }
 
 func Test_getAppDetails(t *testing.T) {
-	type args struct {
-		path         string
-		relayMetrics map[string]interface{}
-	}
 	tests := []struct {
-		name string
-		args args
-		want AppDetails
+		name    string
+		path    string
+		sdkInfo SDKInfo
+		want    AppDetails
 	}{
 		{
 			name: "Python Django",
-			args: args{
-				path: "result/python/django/20210923-152931-snbclwa/baseline",
-				relayMetrics: func() map[string]interface{} {
-					sdk := make(map[string]interface{})
-					sdk["name"] = "sentry.python"
-					sdk["version"] = "1.3.0"
-
-					relayMetrics := make(map[string]interface{})
-					relayMetrics["sdk"] = sdk
-					return relayMetrics
-				}(),
+			path: "result/python/django/20210923-152931-snbclwa/baseline",
+			sdkInfo: SDKInfo{
+				Name:    "sentry.python",
+				Version: "1.3.0",
 			},
 			want: AppDetails{
 				Language:   "python",
@@ -64,17 +54,10 @@ func Test_getAppDetails(t *testing.T) {
 		},
 		{
 			name: "JavaScript Express",
-			args: args{
-				path: "result/javascript/express/20210923-145159-yaubxsi/baseline",
-				relayMetrics: func() map[string]interface{} {
-					sdk := make(map[string]interface{})
-					sdk["name"] = "sentry.javascript"
-					sdk["version"] = "6.11.0"
-
-					relayMetrics := make(map[string]interface{})
-					relayMetrics["sdk"] = sdk
-					return relayMetrics
-				}(),
+			path: "result/javascript/express/20210923-145159-yaubxsi/baseline",
+			sdkInfo: SDKInfo{
+				Name:    "sentry.javascript",
+				Version: "6.11.0",
 			},
 			want: AppDetails{
 				Language:   "javascript",
@@ -86,7 +69,7 @@ func Test_getAppDetails(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getAppDetails(tt.args.path, tt.args.relayMetrics); !reflect.DeepEqual(got, tt.want) {
+			if got := getAppDetails(tt.path, tt.sdkInfo); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getConfiguration() = %v, want %v", got, tt.want)
 			}
 		})

--- a/template/report.html.tmpl
+++ b/template/report.html.tmpl
@@ -414,7 +414,12 @@
 
       <hr>
       <h3>First Request to Relay</h3>
-      <pre>{{ .FirstRequestRelay }}</pre>
+      {{ range .Data }}
+      {{ if .TestResult.RelayMetrics.FirstRequest }}
+      <p>{{ .Name }}</p>
+      <pre>{{ .TestResult.RelayMetrics.FirstRequest }}</pre>
+      {{ end }}
+      {{ end }}
 
       <hr>
       <h3>LoadGen Command</h3>


### PR DESCRIPTION
In order to support comparing multiple instrumented runs, RelayMetrics needs to move and be retained for every run that has `fakerelay` deployed.

Add a proper type definition makes it clear what data we can expect to be available to the report template.