### PR TITLE
Document how to add OpenTelementry-instrumented app

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -60,6 +60,8 @@ Follow the steps below to add new platforms or frameworks to use with the `sentr
 
     We typically do not need all the files from TFB to run the app with Postgres. However, it can be trick to remove parts without breaking the whole. We recommend deleting `README.md`, `benchmark_config.json` and `config.toml` that most apps include.
 
+    However, avoid the temptation to change the app to remove unused parts. For most apps, it would be too much work to try to split out just what is used, for very little if any benefit. Try to keep the code as close to upstream as possible because that makes it easier to apply upstream patches later.
+
     ```zsh
     rm platform/${LANGUAGE:l}/${FRAMEWORK:l}/baseline/{README.md,benchmark_config.json,config.toml}
     ```
@@ -103,6 +105,7 @@ Follow the steps below to add new platforms or frameworks to use with the `sentr
     - Add Sentry middlewares as necessary.
     - Both error monitoring and tracing should have their sample rates configured to 100% (`1.0`), unless you are interested in benchmarking alternative configurations.
     - You may enable debug logging while you test things out, but we recommend disabling it before committing.
+    - Enable database instrumentation for PostgreSQL.
 
     You can use `git` to double check your minimal edits:
 
@@ -118,7 +121,60 @@ Follow the steps below to add new platforms or frameworks to use with the `sentr
 
     As with the baseline app, make adjustments as needed and repeat until success.
 
+    There should be a transaction for every incoming request and spans for all reads and writes from/to the database.
+
 10. Do a full run with both baseline and instrumented apps.
+
+    ```zsh
+    sentry-sdk-benchmark platform/${LANGUAGE:l}/${FRAMEWORK:l}
+    ```
+
+Review your changes one last time, commit and push. Done!
+
+## Add an OpenTelemetry-instrumented App
+
+Comparing a baseline app and a Sentry-instrumented app gives some insight. Adding a second instrumented app can help put results into perspective, in particular to sanity check that Sentry's instrumentation overhead is similar to that of other libraries.
+
+We've chosen to compare with OpenTelemetry because, among other reasons, there are SDKs available for many platforms and because of its vendor neutrality.
+
+The steps to add an OpenTelemetry-instrumented app are similar to steps 7 to 10 above, reproduced here for convenience:
+
+1. Copy `baseline` app to `platform/.../opentelemetry/`:
+
+    ```zsh
+    rsync -avz platform/${LANGUAGE:l}/${FRAMEWORK:l}/{baseline,opentelemetry}/
+    ```
+
+    At this point you might stage files to commit later:
+
+    ```zsh
+    git add platform
+    ```
+
+2. Instrument with OpenTelemetry.
+
+    Make minimal edits to the source code to add OpenTelemetry tracing instrumentation.
+
+    The actual steps will depend on the platform and framework, but these guidelines should be followed:
+
+    - Use a `BatchSpanProcessor`
+    - Use a `ZipkinExporter` using HTTP and the default configuration (it should automatically pick up configuration from the `OTEL_EXPORTER_ZIPKIN_ENDPOINT` environment variable)
+    - Add PostgreSQL database instrumentation (there should be a span for every database interaction: reads and writes)
+    - Add framework-specific instrumentation (there should be at least a span for every incoming request)
+
+    You can use `git` to double check your minimal edits:
+
+    ```zsh
+    git diff -- platform
+    ```
+
+3. Test the OpenTelemetry-instrumented app.
+
+    ```zsh
+    sentry-sdk-benchmark platform/${LANGUAGE:l}/${FRAMEWORK:l}/opentelemetry
+    ```
+
+4. Do a full run with baseline, Sentry-instrumented and OpenTelemetry-instrumented apps.
 
     ```zsh
     sentry-sdk-benchmark platform/${LANGUAGE:l}/${FRAMEWORK:l}


### PR DESCRIPTION
Comparing baseline with apps instrumented with different libraries (Sentry and OpenTelemetry) gives us more insight on how SDKs affect app behavior and performance.

Since we've been adding more apps instrumented with OpenTelemetry, this PR documents the steps so we have a step-by-step guide for anyone to follow.