### PR TITLE
Improve container size for fakerelay and loadgen

### DIFF
--- a/tool/fakerelay/Dockerfile
+++ b/tool/fakerelay/Dockerfile
@@ -1,13 +1,17 @@
-FROM golang:1.17-buster
+FROM golang:1.17-alpine as build-env
 
 WORKDIR /src
-
-EXPOSE 5000
 
 COPY go.mod go.sum* ./
 RUN go mod download
 
 COPY . ./
-RUN go build -o fakerelay
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/fakerelay
 
-ENTRYPOINT ["./fakerelay"]
+FROM scratch
+
+EXPOSE 5000
+
+COPY --from=build-env /go/bin/fakerelay /fakerelay
+
+ENTRYPOINT ["/fakerelay"]

--- a/tool/loadgen/Dockerfile
+++ b/tool/loadgen/Dockerfile
@@ -1,11 +1,15 @@
-FROM golang:1.17-buster
+FROM golang:1.17-alpine as build-env
 
 WORKDIR /src
 
-COPY go.mod go.sum ./
+COPY go.mod go.sum* ./
 RUN go mod download
 
 COPY . ./
-RUN go build -o loadgen
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/loadgen
 
-ENTRYPOINT ["./loadgen"]
+FROM scratch
+
+COPY --from=build-env /go/bin/loadgen /loadgen
+
+ENTRYPOINT ["/loadgen"]


### PR DESCRIPTION
I am by no means a go/docker expert but I noticed the fakerelay and especially the loadgen containers are massive.

First I though to use `alpine` instead of `buster` but after some googling I found this article:

> https://petomalina.medium.com/using-go-mod-download-to-speed-up-golang-docker-builds-707591336888

The resulting containers are now super small (~10MB each) which I'm not sure matters too much, but it also doesn't seem to have any impact on the benchmarks so it's probably not a bad thing 😄 

If this makes no sense or there is a good reasons for keeping the buster image feel free to close this PR!