### PR TITLE
report: make Y axis scale linear again

### DIFF
--- a/template/js/script.js
+++ b/template/js/script.js
@@ -51,7 +51,6 @@ function drawChart() {
 
   new Dygraph(document.getElementById('percentileLatency'), data, {
     title: 'Latency by Percentile Distribution',
-    logscale: true,
     ylabel: 'Latency (ms)',
     xlabel: 'Percentile',
     legend: 'always',


### PR DESCRIPTION
Fixes unintended behavior change introduced in a3d89b756cf153aaffead2aa416a854010ea5248.

Closes #58.

---

This is what a report graph looks like with this change applied:

![after](https://user-images.githubusercontent.com/88819/137890926-4cce3026-6a24-41e5-aa2f-9650b0564e55.png)
